### PR TITLE
Task Width Normalization

### DIFF
--- a/src/app/components/task/task.component.html
+++ b/src/app/components/task/task.component.html
@@ -1,4 +1,4 @@
-<mat-card class="example-card" appearance="outlined">
+<mat-card class="taskCard" appearance="outlined">
   <mat-card-header class="custom-card-header">
     <div class="header-content">
       <mat-card-title>{{task.title}}</mat-card-title>

--- a/src/app/components/task/task.component.scss
+++ b/src/app/components/task/task.component.scss
@@ -1,5 +1,6 @@
 .taskCard {
     width: 300px;
+    margin: 5px 0;
 }
 
 .example-card-footer {

--- a/src/app/components/task/task.component.scss
+++ b/src/app/components/task/task.component.scss
@@ -1,5 +1,5 @@
-.example-card {
-    max-width: 400px;
+.taskCard {
+    width: 300px;
 }
 
 .example-card-footer {
@@ -44,4 +44,25 @@ mat-expansion-panel mat-action-row {
 
 .actionRow mat-icon {
     cursor: pointer;
+}
+
+@media screen and (min-width: 350px) {
+    .taskCard {
+        width: 350px;
+    }
+    
+}
+
+@media screen and (min-width: 375px) {
+    .taskCard {
+        width: 375px;
+    }
+    
+}
+
+@media screen and (min-width: 400px) {
+    .taskCard {
+        width: 400px;
+    }
+    
 }


### PR DESCRIPTION
# Task Width Normalization
* [Task width for mobile has been normalized and media queries have been added to make them responsive to the phone width.](https://github.com/Revivedaniel/Lightweight-Task-Manager/commit/25b37dc708e1f44fbb9f640860178db2b65a8cc9)
* [Added a little margin between tasks on the homepage so help visual distinction.](https://github.com/Revivedaniel/Lightweight-Task-Manager/commit/ea84fb89dcea58012e6a03d4d5c569aa4a094356)

closes #6 